### PR TITLE
Use html table to display leaderboard

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,5 +3,22 @@
     <head>
         <title>Kelo</title>
     </head>
-    <script src = "kelo.js"></script>
+    <style>
+        td {
+            padding: 0.1em 15px;
+            font-size: 2vmax;
+        }
+
+        .main {
+            display: flex;
+            justify-content: center;
+        }
+    </style>
+
+    <body>
+        <div class="main">
+            <table id="elo-table"></table>
+        </div>
+        <script src = "kelo.js"></script>
+    </body>
 </html>

--- a/kelo.js
+++ b/kelo.js
@@ -26,7 +26,7 @@ for (let i = 0; i < data.length; i++) {
 
   let row = document.createElement('tr');
 
-  row.appendChild(createTextElement('td', i + '.'))
+  row.appendChild(createTextElement('td', i + 1 + '.'))
   row.appendChild(createTextElement('td', name));
 
   let eloText = Math.round(elo*10)/10;
@@ -34,8 +34,6 @@ for (let i = 0; i < data.length; i++) {
     eloText += '?';
   }
   row.appendChild(createTextElement('td', eloText));
-  row.appendChild(createTextElement('td', played));
-
 
   table.appendChild(row);
 }

--- a/kelo.js
+++ b/kelo.js
@@ -10,20 +10,32 @@ function readfile(filepath){
     return result;
 }
 
-data = JSON.parse(readfile("kelo.txt"));
-
-document.write('<font size='+(6*((innerWidth/innerHeight)**0.2))+'vw>');
-document.write('<div style="position: relative; width: 100%;">');
-for(let i = 0; i < data.length; i++){  
-  document.write('<div style="position: absolute; left: '+(10*(innerWidth/innerHeight)**1.5)+'vw; top: '+ (i*5) + 'vh;">');
-  document.write(i+1 + ".");
-  document.write('<span style="position: absolute; left: '+(4000/innerHeight)+'vw; top: 0;">'  + data[i][0] + '</span>');
-  document.write('<span style="position: absolute; left: '+(20000/innerHeight)+'vw; top: 0;">' + Math.round(data[i][1]*10)/10);
-  if(data[i][2] < 5){
-    document.write("?")
-  }
-  document.write('</span>')
-  document.write('</div>');
+function createTextElement(type, text) {
+  let elem = document.createElement(type);
+  elem.textContent = text;
+  return elem;
 }
-document.write('</div>');
-document.write("</font>");
+
+let data = JSON.parse(readfile("kelo.txt"));
+
+
+let table = document.getElementById('elo-table');
+
+for (let i = 0; i < data.length; i++) {
+  let [name, elo, played] = data[i];
+
+  let row = document.createElement('tr');
+
+  row.appendChild(createTextElement('td', i + '.'))
+  row.appendChild(createTextElement('td', name));
+
+  let eloText = Math.round(elo*10)/10;
+  if (played < 5) {
+    eloText += '?';
+  }
+  row.appendChild(createTextElement('td', eloText));
+  row.appendChild(createTextElement('td', played));
+
+
+  table.appendChild(row);
+}


### PR DESCRIPTION
Switch to a html table to format the scoreboard. This should fix display problems on some smaller screens like in the screenshot below.
![photo_2023-03-17_10-53-11](https://user-images.githubusercontent.com/28290486/225857725-5357ec26-6cfa-4de9-bc0f-abbcaa6e6ef5.jpg)
